### PR TITLE
fix: unable to find main

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@mytiki/l0-index-plugin",
   "version": "0.0.5",
   "description": "Plugin for easy client interfacing with the L0 Index API",
-  "main": "index.js",
+  "main": "lib/index.js",
   "scripts": {
     "build": "tsc --project tsconfig.build.json",
     "format": "prettier --write \"src/**/*.{ts,js}\"",


### PR DESCRIPTION
Fixing bug: "The package may have incorrect main/module/exports specified in its package.json."